### PR TITLE
[Fix] Update template logic for setting listing duration

### DIFF
--- a/Agora.Addons.Disqord/Commands/Modules/SlashCommands/EconomyModule.cs
+++ b/Agora.Addons.Disqord/Commands/Modules/SlashCommands/EconomyModule.cs
@@ -88,8 +88,7 @@ namespace Agora.Addons.Disqord.Commands
 
             return Response(new LocalInteractionMessageResponse()
                     .AddEmbed(new LocalEmbed().WithColor(Color.Teal)
-                                              .WithDescription($"{Context.Author.Mention} gave {user.Mention} {donation}"))
-                    .WithIsEphemeral());
+                                              .WithDescription($"{Context.Author.Mention} gave {user.Mention} {donation}")));
         }
 
         [RequireManager]
@@ -161,7 +160,7 @@ namespace Agora.Addons.Disqord.Commands
                 else
                     embeds.Add(new LocalEmbed().WithColor(Color.Red)
                                                .WithTitle($"Failed to add {donation} to")
-                                               .WithDescription(string.Join(", ", failures)));
+                                               .WithDescription(string.Join(Environment.NewLine, failures)));
 
                 return Response(new LocalInteractionMessageResponse().WithEmbeds(embeds).WithIsEphemeral());
             }

--- a/Agora.Addons.Disqord/Commands/Modules/SlashCommands/TemplateModule.Add.cs
+++ b/Agora.Addons.Disqord/Commands/Modules/SlashCommands/TemplateModule.Add.cs
@@ -77,7 +77,7 @@ namespace Agora.Addons.Disqord.Commands
 
                 auctionTemplate.Currency ??= Settings.DefaultCurrency;
 
-                if (auctionTemplate.MaxBidIncrease == 0) auctionTemplate.MaxBidIncrease = (double)auctionTemplate.Currency.MinAmount;
+                if (auctionTemplate.MinBidIncrease == 0) auctionTemplate.MinBidIncrease = (double)auctionTemplate.Currency.MinAmount;
 
                 var defaultDuration = Settings.DefaultDuration == TimeSpan.Zero
                     ? Settings.MinimumDurationDefault
@@ -85,7 +85,7 @@ namespace Agora.Addons.Disqord.Commands
                         : Settings.MaximumDuration
                     : Settings.DefaultDuration;
 
-                auctionTemplate.Duration = duration == default ? defaultDuration : duration;
+                if (auctionTemplate.Duration == default) auctionTemplate.Duration = defaultDuration;
 
                 if (!auctionTemplate.Validate(out var error)) return ErrorResponse(isEphimeral:true, embeds: new LocalEmbed().WithDescription(error));
 


### PR DESCRIPTION
Fixes error where template auctions use the default duration instead of the defined template duration.